### PR TITLE
Update PathSanity.py

### DIFF
--- a/src/Mod/Path/PathScripts/PathSanity.py
+++ b/src/Mod/Path/PathScripts/PathSanity.py
@@ -404,8 +404,8 @@ class CommandPathSanity:
 
         # Save the report
 
-        reportraw = self.outputpath + 'setupreport.asciidoc'
-        reporthtml = self.outputpath + 'setupreport.html'
+        reportraw = self.outputpath + job.PostProcessorOutputFile + '.asciidoc'
+        reporthtml = self.outputpath + job.PostProcessorOutputFile + '.html'
         with open(reportraw, 'w') as fd:
             fd.write(report)
             fd.close()

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -5737,7 +5737,7 @@ void CmdSketcherConstrainRadiam::activated(int iMsg)
             if(!commandopened)
                 openCommand(QT_TRANSLATE_NOOP("Command", "Add radiam constraint"));
             for (std::vector< std::pair<int, double> >::iterator it = geoIdRadiamMap.begin(); it != geoIdRadiamMap.end(); ++it) {
-                if (Obj->getGeometry(it->first)->getTypeId() == Part::GeomArcOfCircle::getClassTypeId() or isBsplinePole(Obj, it->first)) {
+                if (Obj->getGeometry(it->first)->getTypeId() == Part::GeomArcOfCircle::getClassTypeId() || isBsplinePole(Obj, it->first)) {
                     if(nonpoles) {
                         Gui::cmdAppObjectArgs(Obj, "addConstraint(Sketcher.Constraint('Radius',%d,%f)) ", it->first, it->second);
                     }


### PR DESCRIPTION
Output fillename for the report is now the same as the postprocessor job (job.PostProcessorOutputFile), this way the setup file will be autoloaded in LinuxCNC qtDraggon ui and others based on probe-basic. https://linuxcnc.org/docs/devel/html/gui/qtdragon.html#_setup_tab
There is some error checking missing, the check to see if the job.PostProcessorOutputFile is not empty is not there for example. But since the report can only be generated when there is a postprocessor file this is not a big problem.